### PR TITLE
34 tester invariants climber

### DIFF
--- a/tests/climber_test.py
+++ b/tests/climber_test.py
@@ -52,3 +52,4 @@ def test_settings(control: "pyfrc.test_support.controller.TestController", robot
         for climber in (robot.climber_left, robot.climber_right):
             assert not climber._motor.getInverted()
             assert climber._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless
+            assert climber._motor.getIdleMode() == rev.CANSparkMax.IdleMode.kBrake

--- a/tests/climber_test.py
+++ b/tests/climber_test.py
@@ -1,6 +1,8 @@
 import pytest
 import pyfrc.test_support.controller
+import rev
 
+import ports
 from commands.climber.extendclimber import ExtendClimber
 from commands.climber.retractclimber import RetractClimber
 from robot import Robot
@@ -19,7 +21,7 @@ def test_extend(control: "pyfrc.test_support.controller.TestController", robot: 
         assert not cmd.isScheduled()
 
 
-def test_retract(control:  "pyfrc.test_support.controller.TestController", robot: Robot):
+def test_retract(control: "pyfrc.test_support.controller.TestController", robot: Robot):
     with control.run_robot():
         robot.climber_left._sim_motor.setPosition(robot.climber_left.sim_max_height)
         control.step_timing(seconds=0.1, autonomous=False, enabled=True)
@@ -31,3 +33,25 @@ def test_retract(control:  "pyfrc.test_support.controller.TestController", robot
         assert not cmd.isScheduled()
         assert robot.climber_left._sim_motor.getPosition() == pytest.approx(0.0, rel=0.1)
         assert 0.0 == robot.climber_left._motor.get()
+
+
+def test_ports(control: "pyfrc.test_support.controller.TestController", robot: Robot):
+    with control.run_robot():
+        # left
+        assert robot.climber_left._motor.getDeviceId() == 10
+        assert robot.climber_left._switch_up.getChannel() == 0
+        assert robot.climber_left._switch_down.getChannel() == 2
+        # right
+        assert robot.climber_right._motor.getDeviceId() == 9
+        assert robot.climber_right._switch_up.getChannel() == 1
+        assert robot.climber_right._switch_down.getChannel() == 3
+
+
+def test_invariants(control: "pyfrc.test_support.controller.TestController", robot: Robot):
+    with control.run_robot():
+        # left
+        assert not robot.climber_left._motor.getInverted()
+        assert robot.climber_left._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless
+        # right
+        assert not robot.climber_right._motor.getInverted()
+        assert robot.climber_right._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless

--- a/tests/climber_test.py
+++ b/tests/climber_test.py
@@ -58,7 +58,9 @@ def test_ports(control: "pyfrc.test_support.controller.TestController", robot: R
 
 @mock.patch("rev.CANSparkMax.restoreFactoryDefaults")
 @mock.patch("rev.CANSparkMax.setSmartCurrentLimit")
-def test_settings(_, __, control: "pyfrc.test_support.controller.TestController", robot: Robot):
+def test_settings(
+    _, __, control: "pyfrc.test_support.controller.TestController", robot: Robot
+):
     with control.run_robot():
         for climber in (robot.climber_left, robot.climber_right):
             assert not climber._motor.getInverted()

--- a/tests/climber_test.py
+++ b/tests/climber_test.py
@@ -47,11 +47,8 @@ def test_ports(control: "pyfrc.test_support.controller.TestController", robot: R
         assert robot.climber_right._switch_down.getChannel() == 3
 
 
-def test_invariants(control: "pyfrc.test_support.controller.TestController", robot: Robot):
+def test_settings(control: "pyfrc.test_support.controller.TestController", robot: Robot):
     with control.run_robot():
-        # left
-        assert not robot.climber_left._motor.getInverted()
-        assert robot.climber_left._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless
-        # right
-        assert not robot.climber_right._motor.getInverted()
-        assert robot.climber_right._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless
+        for climber in (robot.climber_left, robot.climber_right):
+            assert not climber._motor.getInverted()
+            assert climber._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless

--- a/tests/climber_test.py
+++ b/tests/climber_test.py
@@ -1,8 +1,9 @@
-import pytest
+from unittest import mock
+
 import pyfrc.test_support.controller
+import pytest
 import rev
 
-import ports
 from commands.climber.extendclimber import ExtendClimber
 from commands.climber.retractclimber import RetractClimber
 from robot import Robot
@@ -47,9 +48,13 @@ def test_ports(control: "pyfrc.test_support.controller.TestController", robot: R
         assert robot.climber_right._switch_down.getChannel() == 3
 
 
-def test_settings(control: "pyfrc.test_support.controller.TestController", robot: Robot):
+@mock.patch("rev.CANSparkMax.restoreFactoryDefaults")
+@mock.patch("rev.CANSparkMax.setSmartCurrentLimit")
+def test_settings(_, __, control: "pyfrc.test_support.controller.TestController", robot: Robot):
     with control.run_robot():
         for climber in (robot.climber_left, robot.climber_right):
             assert not climber._motor.getInverted()
             assert climber._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless
             assert climber._motor.getIdleMode() == rev.CANSparkMax.IdleMode.kBrake
+            climber._motor.restoreFactoryDefaults.assert_called_with()
+            climber._motor.setSmartCurrentLimit.assert_called_with(15, 30)


### PR DESCRIPTION
Description
-----------
<!--- Fais un résumé de ce que tu as ajouté. -->
Closes #34 
Ajouter des tests pour les invariant du sous systeme climbere 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Functions use camelCase
    - [x] Variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
- Command and subsytem safety :
    - [x] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [x] No commands or subsytems have a `setName()` method, unless necessary
    - [x] Commands have a `addRequirements()` method that includes all the subsystems they use
- [x] J'ai exécuté tout mon code en simulation.
