### PR TITLE
Added ratchet and modified climber commands

### DIFF
--- a/commands/climber/extendclimber.py
+++ b/commands/climber/extendclimber.py
@@ -8,7 +8,6 @@ from subsystems.climber import Climber
 class ExtendClimber(SequentialCommandGroup, SafeMixin):
     def __init__(self, climber: Climber):
         super().__init__(UnlockRatchet(climber), _ExtendClimber(climber))
-        self.addRequirements(climber)
 
 
 class _ExtendClimber(SafeCommand):

--- a/commands/climber/extendclimber.py
+++ b/commands/climber/extendclimber.py
@@ -1,8 +1,8 @@
 from commands2 import SequentialCommandGroup
 
 from commands.climber.unlockratchet import UnlockRatchet
-from utils.safecommand import SafeCommand, SafeMixin
 from subsystems.climber import Climber
+from utils.safecommand import SafeCommand, SafeMixin
 
 
 class ExtendClimber(SequentialCommandGroup, SafeMixin):

--- a/commands/climber/extendclimber.py
+++ b/commands/climber/extendclimber.py
@@ -1,8 +1,17 @@
-from utils.safecommand import SafeCommand
+from commands2 import SequentialCommandGroup
+
+from commands.climber.unlockratchet import UnlockRatchet
+from utils.safecommand import SafeCommand, SafeMixin
 from subsystems.climber import Climber
 
 
-class ExtendClimber(SafeCommand):
+class ExtendClimber(SequentialCommandGroup, SafeMixin):
+    def __init__(self, climber: Climber):
+        super().__init__(UnlockRatchet(climber), _ExtendClimber(climber))
+        self.addRequirements(climber)
+
+
+class _ExtendClimber(SafeCommand):
     def __init__(self, climber: Climber):
         super().__init__()
         self.climber = climber

--- a/commands/climber/lockratchet.py
+++ b/commands/climber/lockratchet.py
@@ -1,0 +1,27 @@
+import wpilib
+
+from subsystems.climber import Climber
+from utils.property import autoproperty
+from utils.safecommand import SafeCommand
+
+
+class LockRatchet(SafeCommand):
+    delay = autoproperty(0.1)
+
+    def __init__(self, climber: Climber):
+        super().__init__()
+        self.climber = climber
+        self.addRequirements(climber)
+        self.timer = wpilib.Timer()
+
+    def initialize(self):
+        self.timer.restart()
+
+    def execute(self):
+        self.climber.lockRatchet()
+
+    def isFinished(self) -> bool:
+        return self.timer.get() >= self.delay
+
+    def end(self, interrupted: bool):
+        self.timer.stop()

--- a/commands/climber/lockratchet.py
+++ b/commands/climber/lockratchet.py
@@ -6,7 +6,7 @@ from utils.safecommand import SafeCommand
 
 
 class LockRatchet(SafeCommand):
-    delay = autoproperty(0.1)
+    delay = autoproperty(0.5)
 
     def __init__(self, climber: Climber):
         super().__init__()

--- a/commands/climber/retractclimber.py
+++ b/commands/climber/retractclimber.py
@@ -8,7 +8,6 @@ from subsystems.climber import Climber
 class RetractClimber(SequentialCommandGroup, SafeMixin):
     def __init__(self, climber: Climber):
         super().__init__(LockRatchet(climber), _RetractClimber(climber))
-        self.addRequirements(climber)
 
 
 class _RetractClimber(SafeCommand):

--- a/commands/climber/retractclimber.py
+++ b/commands/climber/retractclimber.py
@@ -1,8 +1,17 @@
-from utils.safecommand import SafeCommand
+from commands2 import SequentialCommandGroup
+
+from commands.climber.lockratchet import LockRatchet
+from utils.safecommand import SafeCommand, SafeMixin
 from subsystems.climber import Climber
 
 
-class RetractClimber(SafeCommand):
+class RetractClimber(SequentialCommandGroup, SafeMixin):
+    def __init__(self, climber: Climber):
+        super().__init__(LockRatchet(climber), _RetractClimber(climber))
+        self.addRequirements(climber)
+
+
+class _RetractClimber(SafeCommand):
     def __init__(self, climber: Climber):
         super().__init__()
         self.climber = climber

--- a/commands/climber/retractclimber.py
+++ b/commands/climber/retractclimber.py
@@ -1,11 +1,11 @@
-from commands2 import SequentialCommandGroup
+from commands2 import ParallelCommandGroup
 
 from commands.climber.lockratchet import LockRatchet
 from utils.safecommand import SafeCommand, SafeMixin
 from subsystems.climber import Climber
 
 
-class RetractClimber(SequentialCommandGroup, SafeMixin):
+class RetractClimber(ParallelCommandGroup, SafeMixin):
     def __init__(self, climber: Climber):
         super().__init__(LockRatchet(climber), _RetractClimber(climber))
 

--- a/commands/climber/retractclimber.py
+++ b/commands/climber/retractclimber.py
@@ -1,11 +1,11 @@
-from commands2 import ParallelCommandGroup
+from commands2 import SequentialCommandGroup
 
 from commands.climber.lockratchet import LockRatchet
-from utils.safecommand import SafeCommand, SafeMixin
 from subsystems.climber import Climber
+from utils.safecommand import SafeCommand, SafeMixin
 
 
-class RetractClimber(ParallelCommandGroup, SafeMixin):
+class RetractClimber(SequentialCommandGroup, SafeMixin):
     def __init__(self, climber: Climber):
         super().__init__(LockRatchet(climber), _RetractClimber(climber))
 

--- a/commands/climber/unlockratchet.py
+++ b/commands/climber/unlockratchet.py
@@ -1,0 +1,29 @@
+import wpilib
+
+from subsystems.climber import Climber
+from utils.property import autoproperty
+from utils.safecommand import SafeCommand
+
+
+class UnlockRatchet(SafeCommand):
+    delay = autoproperty(0.5)
+
+    def __init__(self, climber: Climber):
+        super().__init__()
+        self.climber = climber
+        self.addRequirements(climber)
+        self.timer = wpilib.Timer()
+
+    def initialize(self):
+        self.timer.restart()
+
+    def execute(self):
+        self.climber.unload()
+        self.climber.unlockRatchet()
+
+    def isFinished(self) -> bool:
+        return self.timer.get() >= self.delay
+
+    def end(self, interrupted: bool):
+        self.climber.stop()
+        self.timer.stop()

--- a/ports.py
+++ b/ports.py
@@ -25,6 +25,8 @@ climber_motor_left = 10
 intake_motor: Final = 11
 
 # PWM
+climber_servo_right = 0
+climber_servo_left = 1
 
 
 # DIO

--- a/robot.py
+++ b/robot.py
@@ -40,11 +40,13 @@ class Robot(commands2.TimedCommandRobot):
             ports.climber_motor_left,
             ports.climber_left_switch_up,
             ports.climber_left_switch_down,
+            ports.climber_servo_left,
         )
         self.climber_right = Climber(
             ports.climber_motor_right,
             ports.climber_right_switch_up,
             ports.climber_right_switch_down,
+            ports.climber_servo_right,
         )
         self.intake = Intake()
 

--- a/subsystems/climber.py
+++ b/subsystems/climber.py
@@ -18,8 +18,8 @@ class Climber(SafeSubsystem):
     free_limit = autoproperty(30)
     sim_max_height = 100
 
-    ratchet_lock_angle = autoproperty(50)
-    ratchet_unlock_angle = autoproperty(110)
+    ratchet_lock_angle = autoproperty(50.0)
+    ratchet_unlock_angle = autoproperty(110.0)
 
     def __init__(self, port_motor, port_switch_up, port_switch_down, port_ratchet):
         super().__init__()
@@ -28,10 +28,10 @@ class Climber(SafeSubsystem):
             self._motor, "brake", stallLimit=self.stall_limit, freeLimit=self.free_limit
         )
 
-        self._ratchet_motor = wpilib.Servo(port_ratchet)
+        self._ratchet_servo = wpilib.Servo(port_ratchet)
 
-        self._switch_up = Switch(port_switch_up, Switch.Type.NormallyOpen)
-        self._switch_down = Switch(port_switch_down, Switch.Type.NormallyOpen)
+        self._switch_up = Switch(port_switch_up, Switch.Type.NormallyClosed)
+        self._switch_down = Switch(port_switch_down, Switch.Type.NormallyClosed)
 
         if RobotBase.isSimulation():
             self._sim_motor = SparkMaxSim(self._motor)
@@ -61,10 +61,10 @@ class Climber(SafeSubsystem):
         return self._switch_down.isPressed()
 
     def lockRatchet(self):
-        self._ratchet_motor.setAngle(self.ratchet_lock_angle)
+        self._ratchet_servo.setAngle(self.ratchet_lock_angle)
 
     def unlockRatchet(self):
-        self._ratchet_motor.setAngle(self.ratchet_unlock_angle)
+        self._ratchet_servo.setAngle(self.ratchet_unlock_angle)
 
     def simulationPeriodic(self) -> None:
         self._sim_motor.setVelocity(self._motor.get())

--- a/subsystems/climber.py
+++ b/subsystems/climber.py
@@ -56,6 +56,7 @@ class Climber(SafeSubsystem):
             self.stop()
 
     def unload(self):
+        # Bypass security during unload
         self._motor.set(self.speed_unload)
 
     def stop(self):

--- a/tests/climber_test.py
+++ b/tests/climber_test.py
@@ -21,7 +21,7 @@ def test_extend(control: "pyfrc.test_support.controller.TestController", robot: 
             robot.climber_left._motor.get()
         )
         control.step_timing(seconds=0.1, autonomous=False, enabled=True)
-        assert robot.climber_left._ratchet_motor.getAngle() == approx(
+        assert robot.climber_left._ratchet_servo.getAngle() == approx(
             robot.climber_left.ratchet_unlock_angle
         )
         control.step_timing(seconds=0.5, autonomous=False, enabled=True)
@@ -43,7 +43,7 @@ def test_retract(control: "pyfrc.test_support.controller.TestController", robot:
         cmd.schedule()
         control.step_timing(seconds=0.1, autonomous=False, enabled=True)
         assert robot.climber_left.ratchet_lock_angle == approx(
-            robot.climber_left._ratchet_motor.getAngle()
+            robot.climber_left._ratchet_servo.getAngle()
         )
         control.step_timing(seconds=0.5, autonomous=False, enabled=True)
         assert robot.climber_left.speed_down == approx(robot.climber_left._motor.get())

--- a/tests/climber_test.py
+++ b/tests/climber_test.py
@@ -5,9 +5,7 @@ import rev
 from pytest import approx
 
 from commands.climber.extendclimber import ExtendClimber
-from commands.climber.lockratchet import LockRatchet
 from commands.climber.retractclimber import RetractClimber
-from commands.climber.unlockratchet import UnlockRatchet
 from robot import Robot
 from subsystems.climber import Climber
 
@@ -18,15 +16,15 @@ def test_extend(control: "pyfrc.test_support.controller.TestController", robot: 
         cmd = ExtendClimber(robot.climber_left)
         cmd.schedule()
         control.step_timing(seconds=0.1, autonomous=False, enabled=True)
-        assert robot.climber_left.speed_unload == approx(
-            robot.climber_left._motor.get()
+        assert robot.climber_left._motor.get() == approx(
+            robot.climber_left.speed_unload
         )
         control.step_timing(seconds=0.1, autonomous=False, enabled=True)
         assert robot.climber_left._ratchet_servo.getAngle() == approx(
             robot.climber_left.ratchet_unlock_angle
         )
         control.step_timing(seconds=0.5, autonomous=False, enabled=True)
-        assert robot.climber_left.speed_up == approx(robot.climber_left._motor.get())
+        assert robot.climber_left._motor.get() == approx(robot.climber_left.speed_up)
         control.step_timing(seconds=15.0, autonomous=False, enabled=True)
         # If simulationPeriodic works, switch stopped climber from going over max
         assert robot.climber_left._motor.get() == approx(0.0)
@@ -43,11 +41,11 @@ def test_retract(control: "pyfrc.test_support.controller.TestController", robot:
         cmd = RetractClimber(robot.climber_left)
         cmd.schedule()
         control.step_timing(seconds=0.1, autonomous=False, enabled=True)
-        assert robot.climber_left.ratchet_lock_angle == approx(
-            robot.climber_left._ratchet_servo.getAngle()
+        assert robot.climber_left._ratchet_servo.getAngle() == approx(
+            robot.climber_left.ratchet_lock_angle
         )
         control.step_timing(seconds=0.5, autonomous=False, enabled=True)
-        assert robot.climber_left.speed_down == approx(robot.climber_left._motor.get())
+        assert robot.climber_left._motor.get() == approx(robot.climber_left.speed_down)
         control.step_timing(seconds=15.0, autonomous=False, enabled=True)
         assert not cmd.isScheduled()
         assert robot.climber_left._sim_motor.getPosition() == approx(0.0)
@@ -72,7 +70,7 @@ def test_settings(mock_setSmartCurrentLimit, mock_restoreFactoryDefaults):
     mock_restoreFactoryDefaults.assert_not_called()
     mock_setSmartCurrentLimit.assert_not_called()
 
-    climber = Climber(1, 1, 2)
+    climber = Climber(1, 1, 2, 2)
 
     assert not climber._motor.getInverted()
     assert climber._motor.getMotorType() == rev.CANSparkMax.MotorType.kBrushless

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 from typing import List
 from commands2 import Command, Subsystem
 from tests.utils import import_submodules
-from utils.safecommand import SafeMixin
+from utils.safecommand import SafeMixin, SafeCommand
 
 
 def get_commands() -> List[Command or None]:
@@ -15,9 +15,12 @@ def get_commands() -> List[Command or None]:
 
     for mod in results.values():
         for _, cls in inspect.getmembers(mod, inspect.isclass):
-            if issubclass(cls, Command) and cls.__name__ != "SafeCommand":
+            if (
+                issubclass(cls, Command)
+                and cls.__name__ != "SafeCommand"
+                and cls.__name__ != "SequentialCommandGroup"
+            ):
                 cmds.append(cls)
-
     return cmds
 
 
@@ -42,14 +45,10 @@ def test_arguments():
             ), f"Argument {name} of {obj.__name__} has no type annotation"
 
 
-def test_duplicates():
-    command_names = [command.__name__ for command in get_commands()]
-    for name in command_names:
-        assert command_names.count(name) == 1, f"Duplicate command name {name}"
-
-
 def test_requirements():
     for obj in get_commands():
+        if not issubclass(obj, SafeCommand):
+            continue
         addReqs = None
 
         for c in ast.walk(ast.parse(dedent(inspect.getsource(obj.__init__)))):
@@ -66,11 +65,14 @@ def test_requirements():
                             addReqs is None
                         ), f"{obj.__name__} calls addRequirements() multiple times"
                         addReqs = c
+
         assert addReqs is not None, f"{obj.__name__} does not call addRequirements()"
 
         subsystem_args = {}
         for name, arg in get_arguments(obj).items():
-            if isinstance(arg.annotation, type) and issubclass(arg.annotation, Subsystem): # if is a class and is subsystem
+            if isinstance(arg.annotation, type) and issubclass(
+                arg.annotation, Subsystem
+            ):  # if is a class and is subsystem
                 subsystem_args[name] = arg
 
         actual_required_subsystems = []


### PR DESCRIPTION
Added ratchet and made climbercommands private to actually run sequentialcommandgroup with ratchetcommands

Description
-----------
<!--- Fais un résumé de ce que tu as ajouté. -->
Closes #56 

Liste de vérification
---------------------
<!-- Entre les [ ], remplace l'espace par un x lorsque c'est fait. -->
- Writing conventions :
    - [x] English language
    - [x] File names use lowercase without spaces
    - [x] Class names use PascalCase
    - [x] Functions use camelCase
    - [x] Variable names use snake_case
    - [x] Function and command names start with an action verb (get, set, move, start, stop...)
    - [x] Ports respect the naming convention "subsystem" _ "component type" _ "precision"
    - [x] Properties respect the naming convention
- Command and subsytem safety :
    - [x] Commands and subsystems inherit from SafeCommand and SafeSubsystem
    - [x] No commands or subsytems have a `setName()` method, unless necessary
    - [x] Commands have a `addRequirements()` method that includes all the subsystems they use
- [x] J'ai exécuté tout mon code en simulation.
